### PR TITLE
adds missing include

### DIFF
--- a/include/wtf/buffer/detail_/contiguous_model.hpp
+++ b/include/wtf/buffer/detail_/contiguous_model.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <span>
+#include <vector>
 #include <wtf/buffer/detail_/buffer_holder.hpp>
 #include <wtf/buffer/detail_/contiguous_view_model.hpp>
 #include <wtf/concepts/floating_point.hpp>


### PR DESCRIPTION
Not convinced this will fix the downstream problem, but `<vector>` should be included here.